### PR TITLE
Bug Fixes & Version Update

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
           "group": "navigation"
         },
         {
-          "when": "resourceLangId == yaml",
+          "when": "resourceLangId == yaml || resourceLangId == jinja",
           "command": "nokia-wfm.validate",
           "group": "navigation"
         },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nokia-wfm",
   "displayName": "NOKIA_WFM",
   "description": "NOKIA WFM vsCode Developer Plugin",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "icon": "media/Nokia_WFM.png",
   "publisher": "Nokia",
   "engines": { 
@@ -102,7 +102,7 @@
           "group": "navigation"
         },
         {
-          "when": "resourceLangId == yaml && activeEditorIsDirty == true",
+          "when": "resourceScheme == wfm && activeEditorIsDirty == true",
           "command": "workbench.files.action.compareWithSaved",
           "group": "navigation"
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@
  * Copyright 2023 Nokia
  * Licensed under the BSD 3-Clause License.
  * SPDX-License-Identifier: BSD-3-Clause
- */
+*/
 
 'use strict';
 
@@ -27,6 +27,7 @@ export function activate(context: vscode.ExtensionContext) {
 	const fileIgnore : Array<string> = config.get("ignoreTags") ?? [];
 
 	const wfmProvider = new WorkflowManagerProvider(server, username, secretStorage, port, localsave, localpath, timeout, fileIgnore);
+	
 	context.subscriptions.push(vscode.workspace.registerFileSystemProvider('wfm', wfmProvider, { isCaseSensitive: true }));
 	context.subscriptions.push(vscode.window.registerFileDecorationProvider(wfmProvider));
 	wfmProvider.extContext=context;
@@ -77,9 +78,8 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Apply YAML language to all wfm:/actions/* and wfm:/workflows/* files
 	let fileAssociations : {string: string} = vscode.workspace.getConfiguration('files').get('associations') || <{string: string}>{};
-    fileAssociations["/actions/*"] = "yaml";
-    fileAssociations["/workflows/*"] = "yaml";
-	fileAssociations["/templates/*"] = "jinja";
+    fileAssociations["/actions/*"] = "yaml"; // apply YAML language to all wfm:/actions/* files
+
     vscode.workspace.getConfiguration('files').update('associations', fileAssociations);
 
 	// --- WORKFLOW EXAMPLES - When we click the bottom cloud button the nsp-workflow repo
@@ -105,6 +105,7 @@ export function activate(context: vscode.ExtensionContext) {
 			vscode.commands.executeCommand('git.clone', 'https://github.com/nokia/nsp-workflow.git', gitPath);
 		}
 	}));
+	
 	// Set Password for WFM
 	vscode.commands.registerCommand('nokia-wfm.setPassword', async () => {
 		const passwordInput: string = await vscode.window.showInputBox({
@@ -116,7 +117,8 @@ export function activate(context: vscode.ExtensionContext) {
 			secretStorage.store("nsp_wfm_password", passwordInput);
 		};
 	  });
-	// checks if
+	
+	  // checks if
 	vscode.workspace.onDidChangeWorkspaceFolders(async () => {
 		const workspaceFolders =  vscode.workspace.workspaceFolders ?  vscode.workspace.workspaceFolders : [];
 		if (workspaceFolders.find( ({name}) => name === 'nsp-workflow')) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,7 +39,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// // --- A handler for the 'nokia-wfm.validate' command when the user clicks the checkmark
 	context.subscriptions.push(vscode.commands.registerCommand('nokia-wfm.validate', async () => {
-		wfmProvider.validate();
+		wfmProvider.validate(); // validate an action, workflow, or template.
 	}));
 
 	// // --- A handler to Open workflow in Workflow Manager (Webbrowser) when the user clicks the link


### PR DESCRIPTION
### 1. Error Checking:
- Implemented Error Checking so users cannot add a folder within a workflow folder.
- Implemented Error Checking so users cannot add any files within the 'workflows' directory.

### 2. Adding Workflows:
- Users can only create a workflow by adding a folder to the 'workflows' directory'.
- Users can make a copy of a workflow by changing the name within the .yaml definition.

### 3. File Associations:
 - With the file extension VsCode automatically associates the templates and workflows yaml files to .yaml and/or .jinja language files respectively so file associations for templates and workflows were **removed** as they are not necessary, however, we keep the yaml file association for .action files.

### 4. JSON Schema Applied to all workflows
- JSON Schema wasn't applied to all workflow definitions, however, the generateSchema function has been updated and all workflow definitions have the JSON scheme applied to them.

### 5. Version Update
- Extension version has been updated in the package.json and the changelog to version 2.0.0.

### 6. Compare Dirty Button appears for all wfm files:
- Initially, the “compare dirty” button only appears for “yang” files, now it has been updated to appear for all files in the workflow manager.