### PR TITLE
Release 2.0.0: Bug Fixes and Jinja Template Browser Integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
           "group": "navigation"
         },
         {
-          "when": "resourceLangId == yaml",
+          "when": "resourceLangId == yaml || resourceLangId == jinja",
           "command": "nokia-wfm.validate",
           "group": "navigation"
         },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nokia-wfm",
   "displayName": "NOKIA_WFM",
   "description": "NOKIA WFM vsCode Developer Plugin",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "icon": "media/Nokia_WFM.png",
   "publisher": "Nokia",
   "engines": { 
@@ -102,7 +102,7 @@
           "group": "navigation"
         },
         {
-          "when": "resourceLangId == yaml && activeEditorIsDirty == true",
+          "when": "resourceScheme == wfm && activeEditorIsDirty == true",
           "command": "workbench.files.action.compareWithSaved",
           "group": "navigation"
         },

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
           "group": "navigation"
         },
         {
-          "when": "resourceLangId == yaml",
+          "when": "resourceLangId == yaml || resourceLangId == jinja",
           "command": "nokia-wfm.openInBrowser",
           "group": "navigation"
         },
@@ -112,7 +112,7 @@
           "group": "navigation"
         },
         {
-          "when": "resourceLangId == yaml || resourceLangId == jinja",
+          "when": "resourceLangId == yaml",
           "command": "nokia-wfm.validate",
           "group": "navigation"
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@
  * Copyright 2023 Nokia
  * Licensed under the BSD 3-Clause License.
  * SPDX-License-Identifier: BSD-3-Clause
- */
+*/
 
 'use strict';
 
@@ -27,6 +27,7 @@ export function activate(context: vscode.ExtensionContext) {
 	const fileIgnore : Array<string> = config.get("ignoreTags") ?? [];
 
 	const wfmProvider = new WorkflowManagerProvider(server, username, secretStorage, port, localsave, localpath, timeout, fileIgnore);
+	
 	context.subscriptions.push(vscode.workspace.registerFileSystemProvider('wfm', wfmProvider, { isCaseSensitive: true }));
 	context.subscriptions.push(vscode.window.registerFileDecorationProvider(wfmProvider));
 	wfmProvider.extContext=context;
@@ -77,9 +78,8 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// Apply YAML language to all wfm:/actions/* and wfm:/workflows/* files
 	let fileAssociations : {string: string} = vscode.workspace.getConfiguration('files').get('associations') || <{string: string}>{};
-    fileAssociations["/actions/*"] = "yaml";
-    fileAssociations["/workflows/*"] = "yaml";
-	fileAssociations["/templates/*"] = "jinja";
+    fileAssociations["/actions/*"] = "yaml"; // apply YAML language to all wfm:/actions/* files
+
     vscode.workspace.getConfiguration('files').update('associations', fileAssociations);
 
 	// --- WORKFLOW EXAMPLES - When we click the bottom cloud button the nsp-workflow repo
@@ -105,6 +105,7 @@ export function activate(context: vscode.ExtensionContext) {
 			vscode.commands.executeCommand('git.clone', 'https://github.com/nokia/nsp-workflow.git', gitPath);
 		}
 	}));
+	
 	// Set Password for WFM
 	vscode.commands.registerCommand('nokia-wfm.setPassword', async () => {
 		const passwordInput: string = await vscode.window.showInputBox({
@@ -116,7 +117,8 @@ export function activate(context: vscode.ExtensionContext) {
 			secretStorage.store("nsp_wfm_password", passwordInput);
 		};
 	  });
-	// checks if
+	
+	  // checks if
 	vscode.workspace.onDidChangeWorkspaceFolders(async () => {
 		const workspaceFolders =  vscode.workspace.workspaceFolders ?  vscode.workspace.workspaceFolders : [];
 		if (workspaceFolders.find( ({name}) => name === 'nsp-workflow')) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,7 +39,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	// // --- A handler for the 'nokia-wfm.validate' command when the user clicks the checkmark
 	context.subscriptions.push(vscode.commands.registerCommand('nokia-wfm.validate', async () => {
-		wfmProvider.validate();
+		wfmProvider.validate(); // validate an action, workflow, or template.
 	}));
 
 	// // --- A handler to Open workflow in Workflow Manager (Webbrowser) when the user clicks the link

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,7 @@ export function activate(context: vscode.ExtensionContext) {
 	
 	const header = new CodelensProvider(server); 
 	context.subscriptions.push(vscode.languages.registerCodeLensProvider({language: 'yaml', scheme: 'wfm'}, header));
+	context.subscriptions.push(vscode.languages.registerCodeLensProvider({language: 'jinja', scheme: 'wfm'}, header));
 	console.log(header)
 	// // PUBLISHING COMMANDS
 
@@ -79,8 +80,10 @@ export function activate(context: vscode.ExtensionContext) {
 	// Apply YAML language to all wfm:/actions/* and wfm:/workflows/* files
 	let fileAssociations : {string: string} = vscode.workspace.getConfiguration('files').get('associations') || <{string: string}>{};
     fileAssociations["/actions/*"] = "yaml"; // apply YAML language to all wfm:/actions/* files
-
-    vscode.workspace.getConfiguration('files').update('associations', fileAssociations);
+	fileAssociations["/templates/*"] = "jinja"; // apply YAML language to all wfm:/templates/* files - Needed so that icons can show up for templates
+    fileAssociations["/workflows/*"] = "yaml"; // apply YAML language to all wfm:/workflows/* files
+	
+	vscode.workspace.getConfiguration('files').update('associations', fileAssociations);
 
 	// --- WORKFLOW EXAMPLES - When we click the bottom cloud button the nsp-workflow repo
 	// is cloned to the workspace-

--- a/src/providers/WorkflowManagerProvider.ts
+++ b/src/providers/WorkflowManagerProvider.ts
@@ -1637,6 +1637,16 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 					url = prefix+"/actions/"+key;
 				}
 				vscode.env.openExternal(vscode.Uri.parse(url));
+			} else if (uri?.startsWith('wfm:/templates/')) {
+				uri = uri.replace('.jinja', '')
+				const key = uri.toString().substring(15);
+				let url = '';
+				if (isNSPVersion2311) {
+					url = prefix+"/jinja-template/update?jinjaName="+key;
+				} else {
+					url = prefix+"/jinjatemplate/"+key;
+				}
+				vscode.env.openExternal(vscode.Uri.parse(url));
 			} else { // if the active file is in neither
 				let doc = YAML.parse(editor.document.getText());
 				let key = Object.keys(doc).filter((value) => value !== "version")[0];


### PR DESCRIPTION
### 1. Bug Fixes:
  #### FileSystem Operation Error Checking:
  - Implemented Error Checking so users cannot add a folder within a workflow folder.
  - Implemented Error Checking so users cannot add any files within the 'workflows' directory.

   #### Adding Workflows:
  - Users can only create a workflow by adding a folder to the 'workflows' directory'.
  - Users can make a copy of a workflow by changing the name within the .yaml definition.

  #### JSON Schema Applied to all workflows:
  - JSON Schema wasn't applied to all workflow definitions, however, the generateSchema function has been updated and all workflow definitions have the JSON scheme applied to them.
  
  #### Compare Dirty Button appears for all wfm files:
  - Initially, the “compare dirty” button only appears for “yang” files, now it has been updated to appear for all files in the workflow manager.
______

### 2. Version Update -> 2.0.0:
- Extension version has been updated in the package.json and the changelog to version 2.0.0.
_____

### 3. Updated UI endpoints for NSP versions >= 23.11:
- Implemented retrieval of NSP version
- Anywhere the extension is accessing an external NSP UI endpoint, we check if the NSP version is before 23.11 or is >= 23.11 and we set the UI endpoint accordingly.
_____
### 4. Implemented openInBrowserFunctionality for Jinja Templates:
- Users can now click on the 'house' icon above the jinja template file or the CodeLens link at the top of the active editor to be redirected to the template on the NSP UI.
- This is compatible with the old and new NSP UI endpoints as outlined in 7.
