### PR TITLE
Created Shared NSP Client (plugin logs) output channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,3 +158,6 @@ ____
 
 - The command can be called by other extensions (NSP-connect - not released yet) to connect to the NSP server using certain credentials specified by the NSP-connect extension.
 - This does no affect the current functionality of the WFM extension.
+
+### Created Shared NSP Client (plugin logs) output channel:
+- Renamed output channel to `NSP Server (remote logs)`, to align logging with all NSP plugins

--- a/src/providers/WorkflowManagerProvider.ts
+++ b/src/providers/WorkflowManagerProvider.ts
@@ -105,11 +105,12 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 		this.workflow_folders = {};
 
 		// Instantiate the pluginLogs output channel
-		this.pluginLogs = vscode.window.createOutputChannel('nsp-wfm-plugin-logs', {log: true});
+		this.pluginLogs = vscode.window.createOutputChannel('NSP Client (plugin logs)', {log: true});
 
 		// used for FileDecorator        
 		this._eventEmiter = new vscode.EventEmitter(); // Event emitter for file decorations
         this.onDidChangeFileDecorations = this._eventEmiter.event;
+
 		this.localsave = localsave;
 		this.localpath = localpath;
 	}


### PR DESCRIPTION
- Renamed output channel to `NSP Server (remote logs)`, to align logging with all NSP plugins.