### PR TITLE
Updated Logging to align with IM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,3 +170,7 @@ ______
 - Removed buzzwords such as executing.
 - Included regex patterns to check wether filestat belongs to wfm:/.
 - Update File Decorations to only log wfm:/ files & folders.
+
+### [2.0.4]
+
+- Ensured NSP Connect is able to show connected and getNSPVersion without the user having to click on the Workflow Manager Folder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,3 +161,12 @@ ____
 
 ### Created Shared NSP Client (plugin logs) output channel:
 - Renamed output channel to `NSP Server (remote logs)`, to align logging with all NSP plugins
+
+______
+
+### [2.0.3]
+
+- Ensured no logging of non wfm:/ files/folders.
+- Removed buzzwords such as executing.
+- Included regex patterns to check wether filestat belongs to wfm:/.
+- Update File Decorations to only log wfm:/ files & folders.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nokia-wfm",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "activationEvents": [
@@ -18,7 +18,7 @@
   "packages": {
     "": {
       "name": "nokia-wfm",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "dependencies": {
         "@vscode/codicons": "0.0.20",
         "base-64": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nokia-wfm",
   "displayName": "NOKIA_WFM",
   "description": "NOKIA WFM VsCode Developer Plugin",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "icon": "media/Nokia_WFM.png",
   "publisher": "Nokia",
   "engines": { 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nokia-wfm",
   "displayName": "NOKIA_WFM",
   "description": "NOKIA WFM VsCode Developer Plugin",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "icon": "media/Nokia_WFM.png",
   "publisher": "Nokia",
   "engines": { 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         },
         "workflowManager.user": {
           "type": "string",
-          "default": "username",
+          "default": "admin",
           "scope": "window",
           "description": "NSP username"
         },

--- a/src/providers/WorkflowManagerProvider.ts
+++ b/src/providers/WorkflowManagerProvider.ts
@@ -2646,6 +2646,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			DECORATION_CONNECTED.tooltip = "Connecting..."; // revert to original text
 			DECORATION_DISCONNECTED.tooltip = "Not connected!"; // revert to original text
 			this._eventEmiter.fire(vscode.Uri.parse('wfm:/'));
+			await this.readDirectory(vscode.Uri.parse('wfm:/'));
 		}
 		this.workflow_folders = {};
 		this.workflows = {};

--- a/src/providers/WorkflowManagerProvider.ts
+++ b/src/providers/WorkflowManagerProvider.ts
@@ -128,7 +128,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	* revoked after 10min.
 	*/	
 	private async _getAuthToken(): Promise<void> {
-		this.pluginLogs.info("executing _getAuthToken()");
+		this.pluginLogs.info("_getAuthToken()");
 	
 		if (this.authToken) { // Check if we already have a valid authToken
 			const token = await this.authToken;
@@ -209,7 +209,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * Gracefully revoke NSP auth-token.
 	*/	
 	private async _revokeAuthToken(): Promise<void> {
-		this.pluginLogs.info("executing _revokeAuthToken()");
+		this.pluginLogs.info("_revokeAuthToken()");
 		if (this.authToken) {
 			const fetch = require('node-fetch');
 			const base64 = require('base-64');
@@ -242,7 +242,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 */	
 
 	private async _callNSP(url:string, options:{method: string, body?: string, headers?: object, signal?: AbortSignal}): Promise<void> {
-		this.pluginLogs.info("executing _callNSP("+url+")");
+		this.pluginLogs.info("_callNSP("+url+")");
 		const timeout = new AbortController();
         const fetch = require('node-fetch');
 		setTimeout(() => timeout.abort(), this.timeout*1000); // in seconds
@@ -396,7 +396,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	*/
 	private async validateNSPCredentials(ip: string, username: string, password: string): Promise<boolean> {
 
-		this.pluginLogs.info("Executing validateIpCredentials()");
+		this.pluginLogs.info("validateIpCredentials()");
 		const fetch = require('node-fetch');
 		const base64 = require('base-64');
 		const timeout = new AbortController();
@@ -439,7 +439,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be written to the file
 	*/
 	private async _writeWorkflowDocumentation(uri: vscode.Uri, data: string): Promise<void> {
-		this.pluginLogs.info('executing writeWorkflowDocumentation('+ uri +')');
+		this.pluginLogs.info('writeWorkflowDocumentation('+ uri +')');
 
 		let name = uri.toString().split("/")[2] + '.md';
 		if (name.replace('.md', '.yaml') in this.workflows) { // We are modifying an existing workflow documentation (editor)
@@ -463,7 +463,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be written to the file
 	*/
 	private async _updateWorkflowDocumentation(name: string, data: string): Promise<void> {
-		this.pluginLogs.info('executing updateWorkflowDocumentation('+name+')');
+		this.pluginLogs.info('updateWorkflowDocumentation('+name+')');
 		
 		const id = this.workflows[name].id;
 		let url = 'https://'+this.nspAddr+':'+this.port+'/wfm/api/v1/workflow/'+id+'/readme';
@@ -494,7 +494,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be validated by NSP
 	 */
 	private async _validateTemplate(data: string): Promise<void> {
-		this.pluginLogs.info('executing _validateTemplate()');
+		this.pluginLogs.info('_validateTemplate()');
 	
 		// validate Template definition
 		let url = 'https://'+this.nspAddr+':'+this.port+'/wfm/api/v1/jinja-template/validate';
@@ -522,7 +522,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be written to the file
 	 */
 	private async _writeTemplate(name: string, data: string): Promise<void> {
-		this.pluginLogs.info('executing writeTemplate()'); // when adding a file if the file does not end with .jinja throw a vscode error and return
+		this.pluginLogs.info('writeTemplate()'); // when adding a file if the file does not end with .jinja throw a vscode error and return
 		if (!name.endsWith('.jinja')) { // if the newName does not end with .yaml throw a vscode error and return
 			throw vscode.FileSystemError.NoPermissions('Jinja Template filename must end with .jinja');
 		} else {
@@ -563,7 +563,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be written to the file
 	*/
 	private async _updateTemplate(name: string, data: string): Promise<void> {
-		this.pluginLogs.info('executing updateTemplate()');
+		this.pluginLogs.info('updateTemplate()');
 		const id = this.templates[name].id; // get the template id
 
 		// API call to update template:
@@ -610,7 +610,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be written to the template file
 	*/
 	private async _createTemplate(data: string): Promise<void> {
-		this.pluginLogs.info('executing _createTemplate()');
+		this.pluginLogs.info('_createTemplate()');
 		
 		// validate template definition
 		let url = 'https://'+this.nspAddr+':'+this.port+'/wfm/api/v1/jinja-template/validate';
@@ -670,7 +670,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} name - name of the file to be deleted
 	*/
 	private async _deleteTemplate(name: string): Promise<void> {
-		this.pluginLogs.info('executing deleteTemplate(+name+)', name);
+		this.pluginLogs.info('deleteTemplate(+name+)', name);
 
 		const id : string = this.templates[name].id;
 		let url = 'https://'+this.nspAddr+':'+this.port+'/wfm/api/v1/jinja-template/'+id.replace('.jinja', '');
@@ -695,7 +695,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} newName - new name of the file
 	*/
 	private async _renameTemplate(oldName: string, newName: string): Promise<void> {
-		this.pluginLogs.info('executing renameTemplate()');
+		this.pluginLogs.info('renameTemplate()');
 
 		let id = this.templates[oldName].id;
 		let url = "https://"+this.nspAddr+":"+this.port+"/wfm/api/v1/jinja-template/"+id+"/definition";
@@ -727,7 +727,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	*/
 	private async _createWorkflow(temp_name: string, data: string): Promise<void> {
 		
-		this.pluginLogs.info('executing createWorkflow()');
+		this.pluginLogs.info('createWorkflow()');
 		// make a temp folder so VsCode doese't throw up an error in that the folder doesen't exist when created
 		this.workflow_folders[temp_name.replace('.yaml', '')] = new FileStat('', 'directory', 0, 0, data.length, false);
 		let url = 'https://'+this.nspAddr+':'+this.port+'/wfm/api/v1/workflow/validate';
@@ -804,7 +804,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {boolean} rename - flag to rename the workflow
 	*/
 	private async _updateWorkflow(name: string, data: string, rename: boolean): Promise<void> {
-		this.pluginLogs.info("executing updateWorkflow(" + name + ")");
+		this.pluginLogs.info("updateWorkflow(" + name + ")");
 
 		const yaml = require('yaml');
 		let defname = Object.keys(yaml.parse(data)).filter((value) => value !== "version")[0] + '.yaml';
@@ -927,7 +927,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} name - name of the file to be deleted
 	*/
 	private async _deleteWorkflow(name: string): Promise<void> {
-		this.pluginLogs.info('executing deleteWorkflow()');
+		this.pluginLogs.info('deleteWorkflow()');
 		
 		if (this.workflows[name+'.yaml'].signed) {
 			throw vscode.FileSystemError.NoPermissions('Unable to delete SIGNED workflows');
@@ -976,7 +976,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be validated by NSP
 	 */
 	private async _validateWorkflow(data: string): Promise<void> {
-		this.pluginLogs.info('executing _validateWorkflow()');
+		this.pluginLogs.info('_validateWorkflow()');
 
 		// validate workflow definition
 		let url = 'https://'+this.nspAddr+':'+this.port+'/wfm/api/v1/workflow/validate';
@@ -1007,7 +1007,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be written to the file
 	 */
 	private async _writeWorkflowView(name: string, data: string): Promise<void> {
-		this.pluginLogs.info('executing writeWorkflowView()');
+		this.pluginLogs.info('writeWorkflowView()');
 		
 		if (name.replace('.json', '.yaml') in this.workflows) { // We are modifying an existing workflow documentation (editor)
 			// make an api call to get the full view info and then update only the data attribute
@@ -1039,7 +1039,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	*/
 	private async _updateWorkflowView(name: string, data: string): Promise<void> {
 
-		this.pluginLogs.info('executing updateWorkflowView()');
+		this.pluginLogs.info('updateWorkflowView()');
 		const id = this.workflows[name].id;
 		let url = 'https://'+this.nspAddr+':'+this.port+'/wfm/api/v1/workflow/'+id+'/ui'; 
 		let response: any = await this._callNSP(url, {
@@ -1068,7 +1068,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be written to the file
 	 */
 	private async _writeWorkflow(name: string, data: string): Promise<void> {
-		this.pluginLogs.info('executing writeWorkflow('+name+')');
+		this.pluginLogs.info('writeWorkflow('+name+')');
 		if (!name.endsWith('.yaml')) { // if the newName does not end with .yaml throw a vscode error and return
 			throw vscode.FileSystemError.NoPermissions('Workflow filename must end with .yaml');
 		} else {
@@ -1090,7 +1090,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	*/
 	private async _renameWorkflow(oldName: string, newName: string): Promise<void> {
 
-		this.pluginLogs.info("executing renameWorkflow(" + oldName + ", " + newName + ")");
+		this.pluginLogs.info("renameWorkflow(" + oldName + ", " + newName + ")");
 		const yaml = require('yaml');
 		
 		// get workflow definitions
@@ -1120,7 +1120,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be written to the file
 	*/
 	private async _createAction(data: string): Promise<void> {
-		this.pluginLogs.info('executing createAction()');
+		this.pluginLogs.info('createAction()');
 
 		// validate action definition
 		let url = 'https://'+this.nspAddr+':'+this.port+'/wfm/api/v1/action/validate';
@@ -1176,7 +1176,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be written to the file
 	*/
 	private async _updateAction(name: string, data: string, rename: boolean): Promise<void> {
-		this.pluginLogs.info('executing _updateAction()');
+		this.pluginLogs.info('_updateAction()');
 
 		const yaml = require('yaml');
 		let defname = Object.keys(yaml.parse(data)).filter((value) => value !== "version")[0] + '.action';
@@ -1257,7 +1257,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} name - name of the file to be deleted
 	*/
 	private async _deleteAction(name: string): Promise<void> {
-		this.pluginLogs.info('executing deleteAction(+name+)', name);
+		this.pluginLogs.info('deleteAction(+name+)', name);
 		const id : string = this.actions[name].id;
 
 		// delete action
@@ -1282,7 +1282,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be validated by NSP
 	*/
 	private async _validateAction(data: string): Promise<void> {
-		this.pluginLogs.info('executing _validateAction()');
+		this.pluginLogs.info('_validateAction()');
 
 		// validate action definition
 		let url = 'https://'+this.nspAddr+':'+this.port+'/wfm/api/v1/action/validate';
@@ -1313,7 +1313,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be written to the file
 	*/
 	private async _writeAction(name: string, data: string): Promise<void> {
-		this.pluginLogs.info('executing _writeAction()');
+		this.pluginLogs.info('_writeAction()');
 		if (!name.endsWith('.action')) { // if the newName does not end with .yaml throw a vscode error and return
 			throw vscode.FileSystemError.NoPermissions('Action filename must end with .action');
 		} else{
@@ -1334,7 +1334,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} newName - new name of the file
 	*/
 	private async _renameAction(oldName: string, newName: string): Promise<void> {
-		this.pluginLogs.info('executing renameAction()');
+		this.pluginLogs.info('renameAction()');
 		const yaml = require('yaml');
 
 		// get action definitions
@@ -1370,7 +1370,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {vscode.WebviewPanel} panel - webview panel
 	*/
 	private async _getWebviewContent(wfnm: string, exectime: string,execstat: string,execid: string,state_info: string,panel: vscode.WebviewPanel): Promise<string> {
-		this.pluginLogs.info('executing _getWebviewContent()');
+		this.pluginLogs.info('_getWebviewContent()');
 
 		const isNSPVersion2311 = this._fromRelease(23, 11);
 		const nspAddr = this.nspAddr;
@@ -1435,7 +1435,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	*/
 	async validate(): Promise<void> {
 
-		this.pluginLogs.info("Executing validate()");
+		this.pluginLogs.info("validate()");
 		const YAML = require('yaml')
 		const editor = vscode.window.activeTextEditor;
 
@@ -1464,7 +1464,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * Works with NSP New Navigation (since 23.11)
 	*/
 	async openInBrowser(): Promise<void> { // async function to open the workflow in the browser
-		this.pluginLogs.info("Executing openInBrowser()");
+		this.pluginLogs.info("openInBrowser()");
 		const YAML = require('yaml')
 		const editor = vscode.window.activeTextEditor; // gets the active file that the user is in.
 
@@ -1555,7 +1555,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * Method to apply JSON schema to the active text editor
 	*/
 	async applySchema(): Promise<void>{ // applySchema returns a promise of void
-		this.pluginLogs.info("Executing applySchema()");
+		this.pluginLogs.info("applySchema()");
 		const editor = vscode.window.activeTextEditor; // get the active text editor
 		const extURI = this.extContext.extensionUri;
 		let outpath = vscode.Uri.joinPath(extURI, 'schema', 'wfm-schema.json').toString().replace("file://","");
@@ -1583,7 +1583,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * Method to execute a workflow in WFM
 	*/
 	async execute(): Promise<void>{
-		this.pluginLogs.info('executing execute()');
+		this.pluginLogs.info('execute()');
 		const YAML = require('yaml')
 		const editor = vscode.window.activeTextEditor;
 		if (editor) {
@@ -1597,7 +1597,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			var stringConstructor = "test".constructor;
 			var objectConstructor = ({}).constructor;
 
-			vscode.window.showInformationMessage('Executing workflow '+wfnm+' in WFM.');
+			vscode.window.showInformationMessage('workflow '+wfnm+' in WFM.');
 			
 			let attrib: string|undefined="{}";
 			if (ym[wfnm.replace('.yaml', '')].hasOwnProperty('input') === true) {
@@ -1673,7 +1673,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * Method to execute the last workflow in WFM
 	*/
 	async lastResult(): Promise<void> {
-		this.pluginLogs.info('executing lastResult()');
+		this.pluginLogs.info('lastResult()');
 		const YAML = require('yaml');
 		const fetch = require('node-fetch');
 
@@ -1738,7 +1738,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * Method to upload the active file to NSP
 	*/
 	async upload(): Promise<void> {
-		this.pluginLogs.info('executing upload()');
+		this.pluginLogs.info('upload()');
 		const YAML = require('yaml')
 		const editor = vscode.window.activeTextEditor;
 
@@ -1758,7 +1758,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * Method to generate the workflow manager schema and snippets
 	*/
 	async generateSchema(): Promise<void> {
-		this.pluginLogs.info('executing generateSchema()');
+		this.pluginLogs.info('generateSchema()');
 		let data;
 		await this._getAuthToken(); // get auth-token
 		const token = await this.authToken;
@@ -2147,7 +2147,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {vscode.Uri} uri URI of the folder to retrieve from NSP
 	 */	
 	async readDirectory(uri: vscode.Uri): Promise<[string, vscode.FileType][]> {
-		this.pluginLogs.info("executing readDirectory("+uri.toString()+")");
+		this.pluginLogs.info("readDirectory("+uri.toString()+")");
 		let url = undefined;
 
 		if (!this.nspVersion) {
@@ -2244,26 +2244,32 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {vscode.Uri} uri URI of the folder to retrieve from NSP
 	 */	
 	async stat(uri: vscode.Uri): Promise<vscode.FileStat> {
-		this.pluginLogs.info('executing stat('+uri+')');
+		this.pluginLogs.info('stat('+uri+')');
 
-		const path = uri.toString();
-		const pattern = /^wfm:\/([a-z][a-z0-9_-]+)_v\d+$/;
+		const path = uri.toString();		
 
+		// this needs to be the pattern or we have an extra path
+		// the pattern will have the following format: wfm:/workflows/<workflow_name>/<workflow_file> or wfm:/actions/<action_name>.action
+		const pattern = /^wfm:\/(workflows|actions|templates)\/.*/;
+		
 		if (path.endsWith('.')) {
 			throw vscode.FileSystemError.FileNotFound('No Permissions!');
 		}
 		
+		
+		if ((path ==='wfm:/') || (path==='wfm:/workflows') || (path==='wfm:/actions') || (path==='wfm:/templates')) {
+			this.pluginLogs.debug("stat("+path+")");
+			return {
+				type: vscode.FileType.Directory,
+				ctime: 0,
+				mtime: Date.now(),
+				size: 0,
+				permissions: vscode.FilePermission.Readonly
+			};
+		}
+
 		if (pattern.test(path)) {
-			if ((path ==='wfm:/') || (path==='wfm:/workflows') || (path==='wfm:/actions') || (path==='wfm:/templates')) {
-				return {
-					type: vscode.FileType.Directory,
-					ctime: 0,
-					mtime: Date.now(),
-					size: 0,
-					permissions: vscode.FilePermission.Readonly
-				};
-			}
-	
+			this.pluginLogs.debug("stat("+path+")");
 			let path_length = path.split('/').length;
 			if (path.startsWith('wfm:/workflows/') && path_length > 3 && !(path.endsWith('.yaml') || path.endsWith('.json') || path.endsWith('.md'))) {
 				this.pluginLogs.error("No Permission to add a folder/file within a workflow folder!");
@@ -2348,7 +2354,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {vscode.Uri} uri URI of the folder to retrieve from NSP
 	*/
 	async readFile(uri: vscode.Uri): Promise<Uint8Array> { // VsCode readFile function: returns the file content of the file
-		this.pluginLogs.info('executing readFile('+uri.toString()+')');
+		const path = uri.toString();
 		let url = undefined;
 		if (uri.toString().startsWith("wfm:/actions/")) {
 			let id = uri.toString().substring(13).replace('.action', '');
@@ -2370,7 +2376,9 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 		} else {
 			throw vscode.FileSystemError.FileNotADirectory('Unknown Resources!');
 		}
-	
+
+		this.pluginLogs.debug("readFile("+path+")");
+
 		await this._getAuthToken(); // get auth-token
 		const token = await this.authToken;
 		if (!token) {
@@ -2427,7 +2435,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {Object} options allow/enforce to create/overwrite
 	 */
 	async writeFile(uri: vscode.Uri, content: Uint8Array, options: { create: boolean, overwrite: boolean }): Promise<void> {
-		this.pluginLogs.info("executing writeFile("+uri+")");
+		this.pluginLogs.info("writeFile("+uri+")");
 		
 		if (uri.toString().startsWith('wfm:/workflows/')) {
 			if (uri.toString().endsWith('.json')) { // if its a view
@@ -2457,7 +2465,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {{overwrite: boolean}} options additional options
 	*/	
 	async rename(oldUri: vscode.Uri, newUri: vscode.Uri, options: { overwrite: boolean }): Promise<void> {
-		this.pluginLogs.info("executing rename("+oldUri+", "+newUri+")");
+		this.pluginLogs.info("rename("+oldUri+", "+newUri+")");
 
 		if (oldUri.toString().endsWith('.') || newUri.toString().endsWith('.')) {
 			this.pluginLogs.error('No Permissions!')
@@ -2507,7 +2515,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {vscode.Uri} uri URI of the file to delete
 	*/	
 	async delete(uri: vscode.Uri): Promise<void> {
-		this.pluginLogs.info("executing delete("+uri+")");
+		this.pluginLogs.info("delete("+uri+")");
 
 		const path = uri.toString();
 		if (path === "wfm:/workflows") { // no permissions to delete a directory
@@ -2543,7 +2551,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {vscode.Uri} uri URI of the folder to be created
 	*/	
 	createDirectory(uri: vscode.Uri): void {
-		this.pluginLogs.info("executing createDirectory("+uri+")");
+		this.pluginLogs.info("createDirectory("+uri+")");
 		if (uri.toString().endsWith('.')) {
 			throw vscode.FileSystemError.NoPermissions('No Permissions!');
 		}
@@ -2583,8 +2591,9 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {vscode.Uri} uri URI of the folder to retrieve from NSP
 	 */	
 	public provideFileDecoration( uri: vscode.Uri): vscode.ProviderResult<vscode.FileDecoration> {
-		this.pluginLogs.info('executing provideFileDecoration( ' + uri.toString() + ' )');
-		if (uri.toString() === 'wfm:/') {
+
+		const path = uri.toString();
+		if (path === 'wfm:/') {
 			this.pluginLogs.debug("provideFileDecoration(wfm:/)");
 			if (this.nspVersion) {
 				DECORATION_CONNECTED.tooltip = "Connected to "+this.username+"@"+this.nspAddr+" (Release: "+this.nspVersion+")";
@@ -2595,11 +2604,13 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			}
 		}
 		
-		if (uri.toString().startsWith('wfm:/workflows/')) {
+		if (path.startsWith('wfm:/workflows/')) {
+			this.pluginLogs.debug("provideFileDecoration(" + path + ")");
 			const key = uri.toString().substring(15);
 			if (this.workflows[key+'.yaml'].signed) return DECORATION_SIGNED;
 			return DECORATION_UNSIGNED;
 		} else if (uri.toString().startsWith('wfm:/actions/')) {
+			this.pluginLogs.debug("provideFileDecoration(" + path + ")");
 			const key = uri.toString().substring(13);
 			if (this.actions[key].signed) return DECORATION_SIGNED;
 			return DECORATION_UNSIGNED;
@@ -2610,7 +2621,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * Update WorkflowManagerProvider after configuration changes 
 	*/	
 	public async updateSettings() {
-		this.pluginLogs.info("Executing updateSettings()");
+		this.pluginLogs.info("Updating WorkflowManagerProvider after configuration change");
 
 		const config = vscode.workspace.getConfiguration('workflowManager');
 		this.timeout = config.get('timeout') ?? 90; // default 3min

--- a/src/providers/WorkflowManagerProvider.ts
+++ b/src/providers/WorkflowManagerProvider.ts
@@ -116,7 +116,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	}
 
 	dispose() {
-		this.pluginLogs.info("disposing WorkflowManagerProvider()");
+		this.pluginLogs.info("[WFM]: disposing WorkflowManagerProvider()");
 		this._revokeAuthToken();
 		this.pluginLogs.dispose();
 	}
@@ -128,12 +128,12 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	* revoked after 10min.
 	*/	
 	private async _getAuthToken(): Promise<void> {
-		this.pluginLogs.info("_getAuthToken()");
+		this.pluginLogs.info("[WFM]: _getAuthToken()");
 	
 		if (this.authToken) { // Check if we already have a valid authToken
 			const token = await this.authToken;
 			if (token) {
-				this.pluginLogs.info("Using existing authToken");
+				this.pluginLogs.info("[WFM]: Using existing authToken");
 				return;
 			} else {
 				this.pluginLogs.warn("Existing authToken is invalid, resetting");
@@ -171,11 +171,11 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 				}).then(async (response: any) => {
 					clearTimeout(timeoutId); // Clear the timeout if fetch is successful
 					const duration = Date.now() - startTS;
-					this.pluginLogs.info("POST", url, "finished within", duration, "ms");
+					this.pluginLogs.info("[WFM]: POST", url, "finished within", duration, "ms");
 	
 					const json = await response.json();
 					if (response.ok) {
-						this.pluginLogs.info("Successfully obtained authToken");
+						this.pluginLogs.info("[WFM]: Successfully obtained authToken");
 						resolve(json.access_token);
 						setTimeout(() => this._revokeAuthToken(), 600000); // automatically revoke token after 10min
 					} else {
@@ -209,7 +209,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * Gracefully revoke NSP auth-token.
 	*/	
 	private async _revokeAuthToken(): Promise<void> {
-		this.pluginLogs.info("_revokeAuthToken()");
+		this.pluginLogs.info("[WFM]: _revokeAuthToken()");
 		if (this.authToken) {
 			const fetch = require('node-fetch');
 			const base64 = require('base-64');
@@ -227,7 +227,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 				body: "token="+token+"&token_type_hint=token"
 			})
 			.then((response:any) => {
-				this.pluginLogs.info("POST", url, response.status);
+				this.pluginLogs.info("[WFM]: POST", url, response.status);
 			});
 		}
 	}
@@ -242,7 +242,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 */	
 
 	private async _callNSP(url:string, options:{method: string, body?: string, headers?: object, signal?: AbortSignal}): Promise<void> {
-		this.pluginLogs.info("_callNSP("+url+")");
+		this.pluginLogs.info("[WFM]: _callNSP("+url+")");
 		const timeout = new AbortController();
         const fetch = require('node-fetch');
 		setTimeout(() => timeout.abort(), this.timeout*1000); // in seconds
@@ -311,9 +311,9 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 					if (response.status >= 400)
 						this.pluginLogs.warn("NSP response:", response.status, body);
 					else if ((body.length < 1000) || (this.pluginLogs.logLevel == vscode.LogLevel.Trace))
-						this.pluginLogs.info("NSP response:", response.status, body);
+						this.pluginLogs.info("[WFM]: NSP response:", response.status, body);
 					else
-						this.pluginLogs.info("NSP response:", response.status, body.substring(0,1000)+'...');
+						this.pluginLogs.info("[WFM]: NSP response:", response.status, body.substring(0,1000)+'...');
 				});
 				return response;
 			})
@@ -342,21 +342,21 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * Note: currently used to select OpenSearch API version
 	*/	
 	private async _getNSPversion(): Promise<void> {
-		this.pluginLogs.info("Requesting NSP version");
+		this.pluginLogs.info("[WFM]: Requesting NSP version");
 		const url = "https://"+this.nspAddr+"/internal/shared-app-banner-utils/rest/api/v1/appBannerUtils/release-version";
-		this.pluginLogs.info("GET", url);
+		this.pluginLogs.info("[WFM]: GET", url);
 		let response: any = await this._callNSP(url, {method: "GET"});
 		if (!response)
 			throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 		if (!response.ok)
-			this.pluginLogs.info("NSP version request failed with", response.status);
+			this.pluginLogs.info("[WFM]: NSP version request failed with", response.status);
 		let json : any = await response.json();		
 		this.nspVersion = json.response.data.nspOSVersion.match(/\d+\.\d+(?=\.\d+)/)[0];
-		this.pluginLogs.info("NSP version:", this.nspVersion);
+		this.pluginLogs.info("[WFM]: NSP version:", this.nspVersion);
 
 		this._eventEmiter.fire(vscode.Uri.parse('wfm:/'));
 
-		this.pluginLogs.info("Requesting OSD version");
+		this.pluginLogs.info("[WFM]: Requesting OSD version");
 		response = await this._callNSP("/logviewer/api/status", {method: "GET"});
 		if (!response)
 			throw vscode.FileSystemError.Unavailable("Lost connection to NSP logviewer (opensearch)");
@@ -396,7 +396,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	*/
 	private async validateNSPCredentials(ip: string, username: string, password: string): Promise<boolean> {
 
-		this.pluginLogs.info("validateIpCredentials()");
+		this.pluginLogs.info("[WFM]: validateIpCredentials()");
 		const fetch = require('node-fetch');
 		const base64 = require('base-64');
 		const timeout = new AbortController();
@@ -439,7 +439,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be written to the file
 	*/
 	private async _writeWorkflowDocumentation(uri: vscode.Uri, data: string): Promise<void> {
-		this.pluginLogs.info('writeWorkflowDocumentation('+ uri +')');
+		this.pluginLogs.info('[WFM]: writeWorkflowDocumentation('+ uri +')');
 
 		let name = uri.toString().split("/")[2] + '.md';
 		if (name.replace('.md', '.yaml') in this.workflows) { // We are modifying an existing workflow documentation (editor)
@@ -463,7 +463,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be written to the file
 	*/
 	private async _updateWorkflowDocumentation(name: string, data: string): Promise<void> {
-		this.pluginLogs.info('updateWorkflowDocumentation('+name+')');
+		this.pluginLogs.info('[WFM]: updateWorkflowDocumentation('+name+')');
 		
 		const id = this.workflows[name].id;
 		let url = 'https://'+this.nspAddr+':'+this.port+'/wfm/api/v1/workflow/'+id+'/readme';
@@ -473,7 +473,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 		}
 
-		this.pluginLogs.info("PUT", url, response.status);
+		this.pluginLogs.info("[WFM]: PUT", url, response.status);
 		if (!response.ok) {
 			throw vscode.FileSystemError.Unavailable('Workflow upload failed! Reason: '+response.statusText);
 		}
@@ -486,7 +486,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 		this.workflow_documentations[name.replace('.yaml', '.md')].mtime = Date.parse(entry.updated_at);
 		this.workflow_documentations[name.replace('.yaml', '.md')].size = entry.details.readme.length;
 		this.saveBackupLocally(name, data);
-		this.pluginLogs.info('completed updating workflow documentation');
+		this.pluginLogs.info('[WFM]: completed updating workflow documentation');
 	}
 
 	/**
@@ -494,7 +494,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be validated by NSP
 	 */
 	private async _validateTemplate(data: string): Promise<void> {
-		this.pluginLogs.info('_validateTemplate()');
+		this.pluginLogs.info('[WFM]: _validateTemplate()');
 	
 		// validate Template definition
 		let url = 'https://'+this.nspAddr+':'+this.port+'/wfm/api/v1/jinja-template/validate';
@@ -503,7 +503,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 		}
 
-		this.pluginLogs.info("POST", url, response.status);
+		this.pluginLogs.info("[WFM]: POST", url, response.status);
 		if (!response.ok) {
 			vscode.window.showErrorMessage('Template validation failed!');
 		} else {
@@ -522,7 +522,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be written to the file
 	 */
 	private async _writeTemplate(name: string, data: string): Promise<void> {
-		this.pluginLogs.info('writeTemplate()'); // when adding a file if the file does not end with .jinja throw a vscode error and return
+		this.pluginLogs.info('[WFM]: writeTemplate()'); // when adding a file if the file does not end with .jinja throw a vscode error and return
 		if (!name.endsWith('.jinja')) { // if the newName does not end with .yaml throw a vscode error and return
 			throw vscode.FileSystemError.NoPermissions('Jinja Template filename must end with .jinja');
 		} else {
@@ -538,7 +538,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 					throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 				}
 
-				this.pluginLogs.info("GET", url, response.status);
+				this.pluginLogs.info("[WFM]: GET", url, response.status);
 				if (!response.ok) {
 					this.pluginLogs.info(response);
 					throw vscode.FileSystemError.FileNotFound('Template not found');
@@ -563,12 +563,12 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be written to the file
 	*/
 	private async _updateTemplate(name: string, data: string): Promise<void> {
-		this.pluginLogs.info('updateTemplate()');
+		this.pluginLogs.info('[WFM]: updateTemplate()');
 		const id = this.templates[name].id; // get the template id
 
 		// API call to update template:
 		let url = 'https://'+this.nspAddr+':'+this.port+'/wfm/api/v1/jinja-template/'+id;
-		this.pluginLogs.info('url: ', url);
+		this.pluginLogs.info('[WFM]: url: ', url);
 		let response: any = await this._callNSP(url, {
 			method: 'PUT',
 			body: data
@@ -577,7 +577,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 		}
 
-		this.pluginLogs.info("PUT", url, response.status);
+		this.pluginLogs.info("[WFM]: PUT", url, response.status);
 		if (!response.ok) {
 			throw vscode.FileSystemError.Unavailable('Template upload failed! Reason: '+response.statusText);
 		}
@@ -602,7 +602,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 		}
 		await vscode.commands.executeCommand("workbench.files.action.refreshFilesExplorer");
 		this.saveBackupLocally(name, data);
-		this.pluginLogs.info('completed updating template');
+		this.pluginLogs.info('[WFM]: completed updating template');
 	}
 
 	/**
@@ -610,7 +610,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be written to the template file
 	*/
 	private async _createTemplate(data: string): Promise<void> {
-		this.pluginLogs.info('_createTemplate()');
+		this.pluginLogs.info('[WFM]: _createTemplate()');
 		
 		// validate template definition
 		let url = 'https://'+this.nspAddr+':'+this.port+'/wfm/api/v1/jinja-template/validate';
@@ -622,7 +622,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 		}
 
-		this.pluginLogs.info("POST", url, response.status);
+		this.pluginLogs.info("[WFM]: POST", url, response.status);
 		if (!response.ok) {
 			throw vscode.FileSystemError.Unavailable('Template validation failed!');
 		}
@@ -644,7 +644,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 		}
 
-		this.pluginLogs.info("POST", url, response.status);
+		this.pluginLogs.info("[WFM]: POST", url, response.status);
 		if (!response.ok) {
 			throw vscode.FileSystemError.Unavailable('Template creation failed! Reason: '+response.statusText);
 		}
@@ -670,7 +670,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} name - name of the file to be deleted
 	*/
 	private async _deleteTemplate(name: string): Promise<void> {
-		this.pluginLogs.info('deleteTemplate(+name+)', name);
+		this.pluginLogs.info('[WFM]: deleteTemplate(+name+)', name);
 
 		const id : string = this.templates[name].id;
 		let url = 'https://'+this.nspAddr+':'+this.port+'/wfm/api/v1/jinja-template/'+id.replace('.jinja', '');
@@ -681,7 +681,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 		}
 
-		this.pluginLogs.info("DELETE", url, response.status);
+		this.pluginLogs.info("[WFM]: DELETE", url, response.status);
 		if (!response.ok) {
 			throw vscode.FileSystemError.Unavailable('Template deletion failed! Reason: '+response.statusText);
 		}
@@ -695,7 +695,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} newName - new name of the file
 	*/
 	private async _renameTemplate(oldName: string, newName: string): Promise<void> {
-		this.pluginLogs.info('renameTemplate()');
+		this.pluginLogs.info('[WFM]: renameTemplate()');
 
 		let id = this.templates[oldName].id;
 		let url = "https://"+this.nspAddr+":"+this.port+"/wfm/api/v1/jinja-template/"+id+"/definition";
@@ -707,7 +707,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 		}
 
-		this.pluginLogs.info("GET", url, response.status);
+		this.pluginLogs.info("[WFM]: GET", url, response.status);
 		if (!response.ok) {
 			this.pluginLogs.info(response);
 			throw vscode.FileSystemError.FileNotFound('Template not found');
@@ -727,7 +727,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	*/
 	private async _createWorkflow(temp_name: string, data: string): Promise<void> {
 		
-		this.pluginLogs.info('createWorkflow()');
+		this.pluginLogs.info('[WFM]: createWorkflow()');
 		// make a temp folder so VsCode doese't throw up an error in that the folder doesen't exist when created
 		this.workflow_folders[temp_name.replace('.yaml', '')] = new FileStat('', 'directory', 0, 0, data.length, false);
 		let url = 'https://'+this.nspAddr+':'+this.port+'/wfm/api/v1/workflow/validate';
@@ -739,7 +739,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 		}
 
-		this.pluginLogs.info("POST", url, response.status);
+		this.pluginLogs.info("[WFM]: POST", url, response.status);
 		if (!response.ok) {
 			throw vscode.FileSystemError.Unavailable('Workflow validation failed!');
 		}
@@ -761,7 +761,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 		}
 
-		this.pluginLogs.info("POST", url, response.status);
+		this.pluginLogs.info("[WFM]: POST", url, response.status);
 		if (!response.ok) {
 			throw vscode.FileSystemError.Unavailable('Workflow creation failed! Reason: '+response.statusText);
 		}
@@ -788,13 +788,13 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 		if (!response){
 			throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 		}
-		this.pluginLogs.info("PUT", url, response.status);
+		this.pluginLogs.info("[WFM]: PUT", url, response.status);
 		if (!response.ok) {
 			throw vscode.FileSystemError.Unavailable('Change mode to PUBLISHED failed! Reason: '+response.statusText);
 		}
 		vscode.commands.executeCommand("workbench.files.action.refreshFilesExplorer");
 		vscode.window.showInformationMessage('Success: Workflow published');
-		this.pluginLogs.info("completed createWorkflow()");
+		this.pluginLogs.info("[WFM]: completed createWorkflow()");
 	}
 
 	/**
@@ -804,7 +804,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {boolean} rename - flag to rename the workflow
 	*/
 	private async _updateWorkflow(name: string, data: string, rename: boolean): Promise<void> {
-		this.pluginLogs.info("updateWorkflow(" + name + ")");
+		this.pluginLogs.info("[WFM]: updateWorkflow(" + name + ")");
 
 		const yaml = require('yaml');
 		let defname = Object.keys(yaml.parse(data)).filter((value) => value !== "version")[0] + '.yaml';
@@ -830,7 +830,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 				throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 			}
 
-			this.pluginLogs.info("POST", url, response.status);
+			this.pluginLogs.info("[WFM]: POST", url, response.status);
 			if (!response.ok) {
 				throw vscode.FileSystemError.Unavailable('Workflow validation failed!');
 			}
@@ -849,7 +849,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			}
 			// change to DRAFT
 			url = 'https://'+this.nspAddr+':'+this.port+'/wfm/api/v1/workflow/'+id+'/status';
-			this.pluginLogs.info('url: ', url);
+			this.pluginLogs.info('[WFM]: url: ', url);
 			response = await this._callNSP(url, {
 				method: 'PUT',
 				body: '{"status": "DRAFT"}'
@@ -858,7 +858,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 				throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 			}
 
-			this.pluginLogs.info("PUT", url, response.status);
+			this.pluginLogs.info("[WFM]: PUT", url, response.status);
 			if (!response.ok) {
 				throw vscode.FileSystemError.Unavailable('Change mode to DRAFT failed!');
 			}
@@ -866,7 +866,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 
 			// upload workflow
 			url = 'https://'+this.nspAddr+':'+this.port+'/wfm/api/v1/workflow/'+id+'/definition';
-			this.pluginLogs.info('url: ', url);
+			this.pluginLogs.info('[WFM]: url: ', url);
 			response = await this._callNSP(url, {
 				method: 'PUT',
 				body: data
@@ -875,7 +875,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 				throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 			}
 
-			this.pluginLogs.info("PUT", url, response.status);
+			this.pluginLogs.info("[WFM]: PUT", url, response.status);
 			if (!response.ok) {
 				throw vscode.FileSystemError.Unavailable('Workflow upload failed! Reason: '+response.statusText);
 			}
@@ -890,7 +890,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 				const ctime = Date.parse(entry.created_at);
 				const mtime = Date.parse(entry.updated_at);
 				this.workflows[defname] = new FileStat(id, 'file', ctime, mtime, data.length, false);
-				this.pluginLogs.info('defName in workflows', defname);	
+				this.pluginLogs.info('[WFM]: defName in workflows', defname);	
 				this.readDirectory(vscode.Uri.parse("wfm:/workflows/"));
 			} else { // here we update the workflow cache
 				this.workflows[name].ctime = Date.parse(entry.created_at);
@@ -911,7 +911,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 				throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 			}
 
-			this.pluginLogs.info("PUT", url, response.status);
+			this.pluginLogs.info("[WFM]: PUT", url, response.status);
 			if (!response.ok) {
 				throw vscode.FileSystemError.Unavailable('Change mode to PUBLISHED failed!');
 			}
@@ -919,7 +919,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			await vscode.commands.executeCommand("workbench.files.action.refreshFilesExplorer");
 			this.saveBackupLocally(name, data);
 		}
-		this.pluginLogs.info('completed updating workflow');
+		this.pluginLogs.info('[WFM]: completed updating workflow');
 	}
 
 	/**
@@ -927,7 +927,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} name - name of the file to be deleted
 	*/
 	private async _deleteWorkflow(name: string): Promise<void> {
-		this.pluginLogs.info('deleteWorkflow()');
+		this.pluginLogs.info('[WFM]: deleteWorkflow()');
 		
 		if (this.workflows[name+'.yaml'].signed) {
 			throw vscode.FileSystemError.NoPermissions('Unable to delete SIGNED workflows');
@@ -945,7 +945,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 		}
 
-		this.pluginLogs.info("PUT", url, response.status);
+		this.pluginLogs.info("[WFM]: PUT", url, response.status);
 		if (!response.ok) {
 			throw vscode.FileSystemError.Unavailable('Change mode to DRAFT failed! Reason: '+response.statusText);
 		}
@@ -959,7 +959,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 		if (!response){
 			throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 		}
-		this.pluginLogs.info("DELETE", url, response.status);
+		this.pluginLogs.info("[WFM]: DELETE", url, response.status);
 		if (!response.ok) {
 			throw vscode.FileSystemError.Unavailable('Workflow deletion failed! Reason: '+response.statusText);
 		}
@@ -976,7 +976,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be validated by NSP
 	 */
 	private async _validateWorkflow(data: string): Promise<void> {
-		this.pluginLogs.info('_validateWorkflow()');
+		this.pluginLogs.info('[WFM]: _validateWorkflow()');
 
 		// validate workflow definition
 		let url = 'https://'+this.nspAddr+':'+this.port+'/wfm/api/v1/workflow/validate';
@@ -988,7 +988,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 		}
 
-		this.pluginLogs.info("POST", url, response.status);
+		this.pluginLogs.info("[WFM]: POST", url, response.status);
 		if (!response.ok) {
 			vscode.window.showErrorMessage('Workflow validation failed!');
 		} else {
@@ -1007,7 +1007,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be written to the file
 	 */
 	private async _writeWorkflowView(name: string, data: string): Promise<void> {
-		this.pluginLogs.info('writeWorkflowView()');
+		this.pluginLogs.info('[WFM]: writeWorkflowView()');
 		
 		if (name.replace('.json', '.yaml') in this.workflows) { // We are modifying an existing workflow documentation (editor)
 			// make an api call to get the full view info and then update only the data attribute
@@ -1021,7 +1021,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 				throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 			}
 
-			this.pluginLogs.info("GET", url, response.status);
+			this.pluginLogs.info("[WFM]: GET", url, response.status);
 			if (!response.ok) {
 				throw vscode.FileSystemError.FileNotFound('');
 			}
@@ -1039,7 +1039,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	*/
 	private async _updateWorkflowView(name: string, data: string): Promise<void> {
 
-		this.pluginLogs.info('updateWorkflowView()');
+		this.pluginLogs.info('[WFM]: updateWorkflowView()');
 		const id = this.workflows[name].id;
 		let url = 'https://'+this.nspAddr+':'+this.port+'/wfm/api/v1/workflow/'+id+'/ui'; 
 		let response: any = await this._callNSP(url, {
@@ -1050,7 +1050,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 		}
 
-		this.pluginLogs.info("PUT", url, response.status);
+		this.pluginLogs.info("[WFM]: PUT", url, response.status);
 		if (!response.ok) {
 			throw vscode.FileSystemError.Unavailable('Workflow upload failed! Reason: '+response.statusText);
 		}
@@ -1068,7 +1068,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be written to the file
 	 */
 	private async _writeWorkflow(name: string, data: string): Promise<void> {
-		this.pluginLogs.info('writeWorkflow('+name+')');
+		this.pluginLogs.info('[WFM]: writeWorkflow('+name+')');
 		if (!name.endsWith('.yaml')) { // if the newName does not end with .yaml throw a vscode error and return
 			throw vscode.FileSystemError.NoPermissions('Workflow filename must end with .yaml');
 		} else {
@@ -1090,7 +1090,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	*/
 	private async _renameWorkflow(oldName: string, newName: string): Promise<void> {
 
-		this.pluginLogs.info("renameWorkflow(" + oldName + ", " + newName + ")");
+		this.pluginLogs.info("[WFM]: renameWorkflow(" + oldName + ", " + newName + ")");
 		const yaml = require('yaml');
 		
 		// get workflow definitions
@@ -1102,7 +1102,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 		if (!response){
 			throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 		}
-		this.pluginLogs.info("GET", url, response.status);
+		this.pluginLogs.info("[WFM]: GET", url, response.status);
 		if (!response.ok) {
 			throw vscode.FileSystemError.FileNotFound();
 		}
@@ -1120,7 +1120,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be written to the file
 	*/
 	private async _createAction(data: string): Promise<void> {
-		this.pluginLogs.info('createAction()');
+		this.pluginLogs.info('[WFM]: createAction()');
 
 		// validate action definition
 		let url = 'https://'+this.nspAddr+':'+this.port+'/wfm/api/v1/action/validate';
@@ -1132,7 +1132,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 		}
 
-		this.pluginLogs.info("POST", url, response.status);
+		this.pluginLogs.info("[WFM]: POST", url, response.status);
 		if (!response.ok) {
 			throw vscode.FileSystemError.NoPermissions('Action validation failed!');
 		}
@@ -1154,7 +1154,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 		}
 
-		this.pluginLogs.info("POST", url, response.status);
+		this.pluginLogs.info("[WFM]: POST", url, response.status);
 		if (!response.ok) {
 			throw vscode.FileSystemError.Unavailable('Action creation failed! Reason: '+response.statusText);
 		}
@@ -1176,7 +1176,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be written to the file
 	*/
 	private async _updateAction(name: string, data: string, rename: boolean): Promise<void> {
-		this.pluginLogs.info('_updateAction()');
+		this.pluginLogs.info('[WFM]: _updateAction()');
 
 		const yaml = require('yaml');
 		let defname = Object.keys(yaml.parse(data)).filter((value) => value !== "version")[0] + '.action';
@@ -1204,7 +1204,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 				throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 			}
 
-			this.pluginLogs.info("POST", url, response.status);
+			this.pluginLogs.info("[WFM]: POST", url, response.status);
 			if (!response.ok) {
 				throw vscode.FileSystemError.NoPermissions('Action validation failed!');
 			}
@@ -1226,7 +1226,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 				throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 			}
 
-			this.pluginLogs.info("PUT", url, response.status);
+			this.pluginLogs.info("[WFM]: PUT", url, response.status);
 			if (!response.ok) {
 				throw vscode.FileSystemError.Unavailable('Action upload failed! Reason: '+response.statusText);
 			}
@@ -1257,7 +1257,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} name - name of the file to be deleted
 	*/
 	private async _deleteAction(name: string): Promise<void> {
-		this.pluginLogs.info('deleteAction(+name+)', name);
+		this.pluginLogs.info('[WFM]: deleteAction(+name+)', name);
 		const id : string = this.actions[name].id;
 
 		// delete action
@@ -1269,7 +1269,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 		}
 
-		this.pluginLogs.info("DELETE", url, response.status);
+		this.pluginLogs.info("[WFM]: DELETE", url, response.status);
 		if (!response.ok) {
 			throw vscode.FileSystemError.Unavailable('Action deletion failed! Reason: '+response.statusText);
 		}
@@ -1282,7 +1282,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be validated by NSP
 	*/
 	private async _validateAction(data: string): Promise<void> {
-		this.pluginLogs.info('_validateAction()');
+		this.pluginLogs.info('[WFM]: _validateAction()');
 
 		// validate action definition
 		let url = 'https://'+this.nspAddr+':'+this.port+'/wfm/api/v1/action/validate';
@@ -1294,7 +1294,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 		}
 
-		this.pluginLogs.info("POST", url, response.status);
+		this.pluginLogs.info("[WFM]: POST", url, response.status);
 		if (!response.ok) {
 			vscode.window.showErrorMessage('Action validation failed!');
 		} else {
@@ -1313,7 +1313,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} data - data to be written to the file
 	*/
 	private async _writeAction(name: string, data: string): Promise<void> {
-		this.pluginLogs.info('_writeAction()');
+		this.pluginLogs.info('[WFM]: _writeAction()');
 		if (!name.endsWith('.action')) { // if the newName does not end with .yaml throw a vscode error and return
 			throw vscode.FileSystemError.NoPermissions('Action filename must end with .action');
 		} else{
@@ -1334,7 +1334,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {string} newName - new name of the file
 	*/
 	private async _renameAction(oldName: string, newName: string): Promise<void> {
-		this.pluginLogs.info('renameAction()');
+		this.pluginLogs.info('[WFM]: renameAction()');
 		const yaml = require('yaml');
 
 		// get action definitions
@@ -1346,7 +1346,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 		}
 
-		this.pluginLogs.info("GET", url, response.status);
+		this.pluginLogs.info("[WFM]: GET", url, response.status);
 		if (!response.ok) {
 			throw vscode.FileSystemError.FileNotFound();
 		}
@@ -1370,12 +1370,12 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {vscode.WebviewPanel} panel - webview panel
 	*/
 	private async _getWebviewContent(wfnm: string, exectime: string,execstat: string,execid: string,state_info: string,panel: vscode.WebviewPanel): Promise<string> {
-		this.pluginLogs.info('_getWebviewContent()');
+		this.pluginLogs.info('[WFM]: _getWebviewContent()');
 
 		const isNSPVersion2311 = this._fromRelease(23, 11);
 		const nspAddr = this.nspAddr;
 		const port = this.port;
-		this.pluginLogs.info('isNSPVersion2311: ', isNSPVersion2311);
+		this.pluginLogs.info('[WFM]: isNSPVersion2311: ', isNSPVersion2311);
 		const extURI = this.extContext.extensionUri;
 		const onDiskPath = vscode.Uri.joinPath(extURI, 'media', 'noklogo_black.svg');
 		const catGifSrc = panel.webview.asWebviewUri(onDiskPath);
@@ -1435,7 +1435,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	*/
 	async validate(): Promise<void> {
 
-		this.pluginLogs.info("validate()");
+		this.pluginLogs.info("[WFM]: validate()");
 		const YAML = require('yaml')
 		const editor = vscode.window.activeTextEditor;
 
@@ -1464,7 +1464,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * Works with NSP New Navigation (since 23.11)
 	*/
 	async openInBrowser(): Promise<void> { // async function to open the workflow in the browser
-		this.pluginLogs.info("openInBrowser()");
+		this.pluginLogs.info("[WFM]: openInBrowser()");
 		const YAML = require('yaml')
 		const editor = vscode.window.activeTextEditor; // gets the active file that the user is in.
 
@@ -1555,7 +1555,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * Method to apply JSON schema to the active text editor
 	*/
 	async applySchema(): Promise<void>{ // applySchema returns a promise of void
-		this.pluginLogs.info("applySchema()");
+		this.pluginLogs.info("[WFM]: applySchema()");
 		const editor = vscode.window.activeTextEditor; // get the active text editor
 		const extURI = this.extContext.extensionUri;
 		let outpath = vscode.Uri.joinPath(extURI, 'schema', 'wfm-schema.json').toString().replace("file://","");
@@ -1583,7 +1583,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * Method to execute a workflow in WFM
 	*/
 	async execute(): Promise<void>{
-		this.pluginLogs.info('execute()');
+		this.pluginLogs.info('[WFM]: execute()');
 		const YAML = require('yaml')
 		const editor = vscode.window.activeTextEditor;
 		if (editor) {
@@ -1673,7 +1673,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * Method to execute the last workflow in WFM
 	*/
 	async lastResult(): Promise<void> {
-		this.pluginLogs.info('lastResult()');
+		this.pluginLogs.info('[WFM]: lastResult()');
 		const YAML = require('yaml');
 		const fetch = require('node-fetch');
 
@@ -1738,7 +1738,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * Method to upload the active file to NSP
 	*/
 	async upload(): Promise<void> {
-		this.pluginLogs.info('upload()');
+		this.pluginLogs.info('[WFM]: upload()');
 		const YAML = require('yaml')
 		const editor = vscode.window.activeTextEditor;
 
@@ -1758,7 +1758,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * Method to generate the workflow manager schema and snippets
 	*/
 	async generateSchema(): Promise<void> {
-		this.pluginLogs.info('generateSchema()');
+		this.pluginLogs.info('[WFM]: generateSchema()');
 		let data;
 		await this._getAuthToken(); // get auth-token
 		const token = await this.authToken;
@@ -2043,51 +2043,51 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			if (typeof input[i] === 'object') {
 				Object.keys(input[i]).forEach(function (key) {
 				if (key === 'token_auth') {
-					// this.pluginLogs.info('ignore token_auth')
+					// this.pluginLogs.info('[WFM]: ignore token_auth')
 				} else if (typeof input[i][key] === 'string') {
-					// this.pluginLogs.info('string or password')
+					// this.pluginLogs.info('[WFM]: string or password')
 					properties.push(uiText(key, input[i][key]))
 				} else if (typeof input[i][key] === 'number') {
-					// this.pluginLogs.info('number')
+					// this.pluginLogs.info('[WFM]: number')
 					properties.push(uiNumber(key, input[i][key]))
 				} else if (typeof input[i][key] === 'boolean') {
-					// this.pluginLogs.info('boolean')
+					// this.pluginLogs.info('[WFM]: boolean')
 					properties.push(uiBoolean(key, input[i][key]))
 				} else if (
 					typeof input[i][key] === 'object' &&
 					input[i][key] !== null
 				) {
 					if (input[i][key].length > 0) {
-					// this.pluginLogs.info('list becomes enum')
+					// this.pluginLogs.info('[WFM]: list becomes enum')
 					properties.push(uiEnum(key, input[i][key]))
 					} else {
-					// this.pluginLogs.info('list is list')
+					// this.pluginLogs.info('[WFM]: list is list')
 					properties.push(uiList(key))
 					}
 				} else {
 					// unsupported object
-					// this.pluginLogs.info('obj/list not supported')
+					// this.pluginLogs.info('[WFM]: obj/list not supported')
 				}
 				})
 			} else if (typeof input[i] === 'string') {
 				let key = input[i]
 				if (['neId', 'neName', 'mgmtIP'].includes(key)) {
-				// this.pluginLogs.info('neList: ', key)
+				// this.pluginLogs.info('[WFM]: neList: ', key)
 				properties.push(uiSuggest(key, 'nspWebUI.neList', key))
 				} else if (key === 'port') {
-				// this.pluginLogs.info('port')
+				// this.pluginLogs.info('[WFM]: port')
 				properties.push(uiSuggest(key, 'nspWebUI.portList', 'name'))
 				} else if (key === 'workflow') {
-				// this.pluginLogs.info('workflow')
+				// this.pluginLogs.info('[WFM]: workflow')
 				properties.push(uiSuggest(key, 'nspWebUI.wfList', 'name'))
 				} else if (key === 'intentType') {
-				// this.pluginLogs.info('intentType')
+				// this.pluginLogs.info('[WFM]: intentType')
 				properties.push(uiSuggest(key, 'nspWebUI.intentTypeList', 'name'))
 				} else if (key === 'intent') {
-				// this.pluginLogs.info('intent')
+				// this.pluginLogs.info('[WFM]: intent')
 				properties.push(uiSuggest(key, 'nspWebUI.intentList', 'target'))
 				} else if (key === 'nodes') {
-				// this.pluginLogs.info('nodes')
+				// this.pluginLogs.info('[WFM]: nodes')
 				properties.push(
 					uiSelectPaged(
 					key,
@@ -2096,7 +2096,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 					)
 				)
 				} else if (key === 'ports') {
-				// this.pluginLogs.info('ports')
+				// this.pluginLogs.info('[WFM]: ports')
 				properties.push(
 					uiSelectPaged(
 					key,
@@ -2105,12 +2105,12 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 					)
 				) // eslint-disable-line max-len
 				} else if (key === 'workflows') {
-				// this.pluginLogs.info('workflows')
+				// this.pluginLogs.info('[WFM]: workflows')
 				properties.push(
 					uiSelect(key, 'nspWebUI.wfList', 'name,createBy,modifiedBy')
 				)
 				} else if (key === 'intentTypes') {
-				// this.pluginLogs.info('intentTypes')
+				// this.pluginLogs.info('[WFM]: intentTypes')
 				properties.push(
 					uiSelect(
 					key,
@@ -2119,9 +2119,9 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 					)
 				)
 				} else if (key === 'token_auth') {
-				// this.pluginLogs.info('ignore token_auth')
+				// this.pluginLogs.info('[WFM]: ignore token_auth')
 				} else {
-				// this.pluginLogs.info('string or password')
+				// this.pluginLogs.info('[WFM]: string or password')
 				properties.push(uiText(input[i], ''))
 				}
 			} else {
@@ -2147,7 +2147,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {vscode.Uri} uri URI of the folder to retrieve from NSP
 	 */	
 	async readDirectory(uri: vscode.Uri): Promise<[string, vscode.FileType][]> {
-		this.pluginLogs.info("readDirectory("+uri.toString()+")");
+		this.pluginLogs.info("[WFM]: readDirectory("+uri.toString()+")");
 		let url = undefined;
 
 		if (!this.nspVersion) {
@@ -2173,7 +2173,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 			throw vscode.FileSystemError.Unavailable("Lost connection to NSP");
 		}
 
-		this.pluginLogs.info("GET", url, response.status);
+		this.pluginLogs.info("[WFM]: GET", url, response.status);
 		if (!response.ok) {
 			throw vscode.FileSystemError.Unavailable('Cannot get workflow list');
 		}
@@ -2228,7 +2228,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 		} else if (uri.toString() === "wfm:/actions") {
 			var result: [string, vscode.FileType][] = (filteredList ?? []).map(entry => [entry.name + '.action', vscode.FileType.File] as [string, vscode.FileType]);			
 		} else if (uri.toString() === "wfm:/templates") {
-			this.pluginLogs.info('URI: wfm:/templates')
+			this.pluginLogs.info('[WFM]: URI: wfm:/templates')
 			var result: [string, vscode.FileType][] = (filteredList ?? []).map(entry => [entry.name + '.jinja', vscode.FileType.File] as [string, vscode.FileType]);			
 		} else if (uri.toString().startsWith("wfm:/workflows/")) { // returns a workflow folder
 			let curr_workflow_name = uri.toString().substring(15);
@@ -2244,7 +2244,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {vscode.Uri} uri URI of the folder to retrieve from NSP
 	 */	
 	async stat(uri: vscode.Uri): Promise<vscode.FileStat> {
-		this.pluginLogs.info('stat('+uri+')');
+		this.pluginLogs.info('[WFM]: stat('+uri+')');
 
 		const path = uri.toString();		
 
@@ -2399,7 +2399,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 
 		let text = await response.text();
 		if (uri.toString().startsWith("wfm:/templates/")) { // if we are in the templates directory
-			this.pluginLogs.info('URI: wfm:/templates');
+			this.pluginLogs.info('[WFM]: URI: wfm:/templates');
 			const yaml = require('yaml');
 			const doc = yaml.parse(text);
 			return Buffer.from(doc.template); // return only the template buffer
@@ -2435,7 +2435,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {Object} options allow/enforce to create/overwrite
 	 */
 	async writeFile(uri: vscode.Uri, content: Uint8Array, options: { create: boolean, overwrite: boolean }): Promise<void> {
-		this.pluginLogs.info("writeFile("+uri+")");
+		this.pluginLogs.info("[WFM]: writeFile("+uri+")");
 		
 		if (uri.toString().startsWith('wfm:/workflows/')) {
 			if (uri.toString().endsWith('.json')) { // if its a view
@@ -2465,7 +2465,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {{overwrite: boolean}} options additional options
 	*/	
 	async rename(oldUri: vscode.Uri, newUri: vscode.Uri, options: { overwrite: boolean }): Promise<void> {
-		this.pluginLogs.info("rename("+oldUri+", "+newUri+")");
+		this.pluginLogs.info("[WFM]: rename("+oldUri+", "+newUri+")");
 
 		if (oldUri.toString().endsWith('.') || newUri.toString().endsWith('.')) {
 			this.pluginLogs.error('No Permissions!')
@@ -2515,7 +2515,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {vscode.Uri} uri URI of the file to delete
 	*/	
 	async delete(uri: vscode.Uri): Promise<void> {
-		this.pluginLogs.info("delete("+uri+")");
+		this.pluginLogs.info("[WFM]: delete("+uri+")");
 
 		const path = uri.toString();
 		if (path === "wfm:/workflows") { // no permissions to delete a directory
@@ -2551,7 +2551,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * @param {vscode.Uri} uri URI of the folder to be created
 	*/	
 	createDirectory(uri: vscode.Uri): void {
-		this.pluginLogs.info("createDirectory("+uri+")");
+		this.pluginLogs.info("[WFM]: createDirectory("+uri+")");
 		if (uri.toString().endsWith('.')) {
 			throw vscode.FileSystemError.NoPermissions('No Permissions!');
 		}
@@ -2572,14 +2572,14 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	saveBackupLocally(name: string, data: string): void {
 		if (this.localsave===true) {
 			let fs = require("fs");
-			this.pluginLogs.info("Saving a backup locally in the temp folder "+this.localpath);
+			this.pluginLogs.info("[WFM]: Saving a backup locally in the temp folder "+this.localpath);
 			let extURI = vscode.Uri.parse("file://"+this.localpath);
 			let filepath = vscode.Uri.joinPath(extURI, name).toString().replace("file://","");
 			fs.writeFile(filepath, data, (err) => {
 				if(err) {
 					this.pluginLogs.error(err); 
 				}
-				this.pluginLogs.info("Successfully saved in local repo."); 
+				this.pluginLogs.info("[WFM]: Successfully saved in local repo."); 
 			});
 		}
 	}
@@ -2621,7 +2621,7 @@ export class WorkflowManagerProvider implements vscode.FileSystemProvider, vscod
 	 * Update WorkflowManagerProvider after configuration changes 
 	*/	
 	public async updateSettings() {
-		this.pluginLogs.info("Updating WorkflowManagerProvider after configuration change");
+		this.pluginLogs.info("[WFM]: Updating WorkflowManagerProvider after configuration change");
 
 		const config = vscode.workspace.getConfiguration('workflowManager');
 		this.timeout = config.get('timeout') ?? 90; // default 3min


### PR DESCRIPTION
- Ensured no logging of non wfm:/ files/folders.
- Removed buzzwords such as executing.
- Included regex patterns to check wether filestat belongs to wfm:/.
- Update File Decorations to only log wfm:/ files & folders.
- Added [WFM] to the start of each log to differentiate logs from different NSP extensions in the output channel.
- Ensured NSP Connect is able to show connected and getNSPVersion without the user having to click on the Workflow Manager Folder.
