### PR TITLE
fix: align esbuild outfile with package.json main entrypoint

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,11 @@
+.git/**
+.github/**
+.vscode/**
+node_modules/**
+src/**
+tsconfig.json
+.gitignore
+.eslintrc.js
+.DS_Store
+build_vsix.py
+*.vsix

--- a/package.json
+++ b/package.json
@@ -383,7 +383,7 @@
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
     "test": "node ./out/test/runTest.js",
-    "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node --packages=external",
+    "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node --packages=external",
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
     "test-compile": "./node_modules/typescript/bin/tsc -p ./"


### PR DESCRIPTION
vsce package was failing because the esbuild script wrote to out/main.js while package.json declared "main": "./out/extension.js". Changed the --outfile to out/extension.js so the two are consistent.

Also added .vscodeignore to exclude src/, tsconfig.json, and dev tooling from the VSIX while keeping out/, media/, and schema/ (required for YAML snippets).